### PR TITLE
Android WebViewへの対応

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ function clickPosition(e) {
   return {x: e.clientX, y: e.clientY};
 }
 function touchPosition(e) {
-  const touch = e.changedTouches[0];
+  var touch = e.changedTouches[0];
   return {x: touch.pageX - window.pageXOffset, y: touch.pageY - window.pageYOffset};
 }
 


### PR DESCRIPTION
Android WebViewの一部バージョンではconstキーワードをstrictモード中で使用することができません。
https://caniuse.com/?search=const

Webpackを用いる一般的なユースケースにおいて、ライブラリコードはstrictモードが有効なコンテキストに配置されます。
このため、Android WebViewでの動作を可能とするためconstを取り除く必要があります。

どうぞよろしくお願いいたします。